### PR TITLE
Proguard Fix and Maven Dev Publishing Fix

### DIFF
--- a/.github/workflows/sonatype-develop.yml
+++ b/.github/workflows/sonatype-develop.yml
@@ -25,8 +25,14 @@ jobs:
           SONATYPE_NEXUS_USERNAME: ${{secrets.SONATYPE_NEXUS_USERNAME}}
           SONATYPE_NEXUS_PASSWORD: ${{secrets.SONATYPE_NEXUS_PASSWORD}}
         run: |
-          echo "Appending dev-suffix to version name"
-          sed -i "/^VERSION_NAME=/s/$/-dev-$GITHUB_RUN_NUMBER/" android/gradle.properties
+          echo "Appending dev-version number to version name"
+          sed -i "/^VERSION_NAME=/s/$/.$GITHUB_RUN_NUMBER/" android/gradle.properties
+
+          echo "Appending dev-version number to version code"
+          sed -i "/^VERSION_CODE=/s/$/$GITHUB_RUN_NUMBER/" android/gradle.properties
+
+          echo "Appending dev-suffix to artifact name"
+          sed -i "/^POM_ARTIFACT_ID=/s/$/-dev/" android/gradle.properties
 
           echo "Create .gpg key from secret"
           echo $SIGNING_KEY_ARMOR | base64 --decode > ./signingkey.asc

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ buildscript {
 	ext.kotlin_version = "1.4.20"
 	repositories {
 		google()
-		jcenter()
 		mavenCentral()
 	}
 	dependencies {
@@ -16,7 +15,6 @@ buildscript {
 
 repositories {
 	google()
-	jcenter()
 	mavenCentral()
 }
 
@@ -130,12 +128,12 @@ dependencies {
 	implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
 	implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2"
 
-	mavenApi 'io.openmobilemaps.mapscore:mapscore-android:1.2.0-dev-15'
+	mavenApi "io.openmobilemaps:mapscore:1.3.0-dev-5"
 	moduleApi project(':mapscore')
 
-	testImplementation 'junit:junit:4.13.1'
-	androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-	androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+	testImplementation "junit:junit:4.13.1"
+	androidTestImplementation "androidx.test.ext:junit:1.1.2"
+	androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"
 }
 
 clean.doLast {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,7 @@ buildscript {
 	repositories {
 		google()
 		mavenCentral()
+		jcenter()
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:4.1.2'
@@ -16,6 +17,7 @@ buildscript {
 repositories {
 	google()
 	mavenCentral()
+	jcenter()
 }
 
 apply plugin: 'com.android.library'
@@ -28,8 +30,8 @@ android {
 	defaultConfig {
 		minSdkVersion 23
 		targetSdkVersion 30
-		versionCode 110
-		versionName  VERSION_NAME
+		versionCode Integer.parseInt(VERSION_CODE)
+		versionName VERSION_NAME
 
 		testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 		consumerProguardFiles 'consumer-rules.pro'
@@ -74,7 +76,6 @@ android {
 		openswissmaps{
 			headers ".cpp_includes"
 			name "openswissmaps"
-			version VERSION_NAME
 		}
 	}
 
@@ -128,7 +129,7 @@ dependencies {
 	implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
 	implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2"
 
-	mavenApi "io.openmobilemaps:mapscore:1.3.0-dev-5"
+	mavenApi "io.openmobilemaps:mapscore-dev:1.3.0.13"
 	moduleApi project(':mapscore')
 
 	testImplementation "junit:junit:4.13.1"

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,2 +1,2 @@
 
--keep class ch.ubique.graphicscore.shared.** { *; }
+-keep class ch.admin.geo.openswissmaps.shared.** { *; }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -26,6 +26,7 @@ SNAPSHOT_REPOSITORY_URL=https://s01.oss.sonatype.org/content/repositories/snapsh
 GROUP=ch.admin.geo.openswissmaps
 POM_ARTIFACT_ID=openswissmaps-sdk
 VERSION_NAME=1.1.0
+VERSION_CODE=110
 PUBLISH_VARIANT=mavenRelease
 
 POM_NAME=openswissmaps-sdk


### PR DESCRIPTION
Exclude reflection-dependant, generated files from obfuscation/optimization.
Switched to MavenCentral dependency for Open Mobile Maps.

Publish Dev-Builds of the Open Swiss Maps SDK with the -dev suffix on Maven Central.