### PR TITLE
Prepare Release 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Open Swiss Maps SDK
 
+## Version 1.1.3 (13.08.2021)
+- update [mapscore to 1.3.2](https://github.com/openmobilemaps/maps-core/releases/tag/1.3.2)
+- update [gps-layer to 0.1.1](https://github.com/openmobilemaps/layer-gps/releases/tag/0.1.1)
+
 ## Version 1.1.2 (11.08.2021)
 - update [mapscore to 1.3.1](https://github.com/openmobilemaps/maps-core/releases/tag/1.3.1)
 - includes the Open Mobile Maps [Gps-Layer](https://github.com/openmobilemaps/layer-gps/releases/tag/0.1.0) module

--- a/android/README.md
+++ b/android/README.md
@@ -41,7 +41,7 @@
 To add the OpenSwissMaps SDK to your Android project, add the following line to your build.gradle
 ```
 dependencies {
-  implementation 'ch.admin.geo.openswissmaps:openswissmaps-sdk:1.1.2'
+  implementation 'ch.admin.geo.openswissmaps:openswissmaps-sdk:1.1.3'
 }
 ```
 Make sure you have mavenCentral() listed in your project repositories. 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,9 +130,9 @@ dependencies {
 	implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
 	implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2"
 
-	mavenApi "io.openmobilemaps:mapscore:1.3.1"
+	mavenApi "io.openmobilemaps:mapscore:1.3.2"
 	moduleApi project(':mapscore')
-	mavenApi "io.openmobilemaps:layer-gps:0.1.0"
+	mavenApi "io.openmobilemaps:layer-gps:0.1.1"
 	moduleApi project(':layergps')
 
 	testImplementation "junit:junit:4.13.1"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -25,8 +25,8 @@ SNAPSHOT_REPOSITORY_URL=https://s01.oss.sonatype.org/content/repositories/snapsh
 
 GROUP=ch.admin.geo.openswissmaps
 POM_ARTIFACT_ID=openswissmaps-sdk
-VERSION_NAME=1.1.2
-VERSION_CODE=112
+VERSION_NAME=1.1.3
+VERSION_CODE=113
 PUBLISH_VARIANT=mavenRelease
 
 POM_NAME=openswissmaps-sdk

--- a/android/src/main/java/ch/admin/geo/openswissmaps/view/SwisstopoMapView.kt
+++ b/android/src/main/java/ch/admin/geo/openswissmaps/view/SwisstopoMapView.kt
@@ -57,6 +57,7 @@ class SwisstopoMapView @JvmOverloads constructor(context: Context, attrs: Attrib
 
     init {
         System.loadLibrary("openswissmaps")
+        System.loadLibrary("layergps")
 
         setupMap(swisstopoMapConfig)
         createBaseLayer(BASE_LAYER_TYPE_DEFAULT)

--- a/shared/src/OpenSwissMapsSharedModule.cpp
+++ b/shared/src/OpenSwissMapsSharedModule.cpp
@@ -11,5 +11,5 @@
  #include "OpenSwissMapsSharedModule.h"
 
 std::string OpenSwissMapsSharedModule::version() {
-    return "1.1.2";
+    return "1.1.3";
 }


### PR DESCRIPTION
Prepare release 1.1.3, update maps-core dependency and load the layer gps library when initializing the Android SwisstopoMapView.