### PR TITLE
Gradle Prefab Headers Copy

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -97,8 +97,21 @@ android {
 	}
 }
 
-task copyHeaders(type: Exec){
-	commandLine './copy_all_header_files_to_include_folder.sh'
+task copyHeaders() {
+	String headersDir = ".cpp_includes"
+	project.delete(headersDir)
+	project.mkdir(headersDir)
+	ConfigurableFileCollection collection = project.files(
+			"src/main/cpp",
+			"../bridging/android/jni",
+			"../shared/public",
+			"../shared/src")
+	project.copy {
+		duplicatesStrategy(DuplicatesStrategy.FAIL)
+		from collection.asFileTree.getFiles()
+		include("**/*.h")
+		into project.file(headersDir)
+	}
 }
 preBuild.dependsOn copyHeaders
 

--- a/android/copy_all_header_files_to_include_folder.sh
+++ b/android/copy_all_header_files_to_include_folder.sh
@@ -1,6 +1,0 @@
-mkdir .cpp_includes
-rm .cpp_includes/*
-find src/main/cpp/ -type f -name '*.h' -exec cp {} .cpp_includes/ \;
-find ../bridging/android/jni -type f -name '*.h' -exec cp {} .cpp_includes/ \;
-find ../shared/public -type f -name '*.h' -exec cp {} .cpp_includes/ \;
-find ../shared/src -type f -name '*.h' -exec cp {} .cpp_includes/ \;


### PR DESCRIPTION
Use gradle to copy header files instead of a unix shell script.