### PR TITLE
Use consistent naming in Android

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,1 @@
-include ':mapscore', ':layergps'
-rootProject.name='OpenSwissMaps'
+rootProject.name='openswissmaps'


### PR DESCRIPTION
Use 'openswissmaps' naming to have it consistent (necessary for correct prefab behavior in including projects).