### PR TITLE
ZoomConfig for Swisstopo Layer Creation, Dependency Update

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/openmobilemaps/layer-gps.git",
         "state": {
           "branch": "develop",
-          "revision": "70e23206ed7953bfe83f4c393f7cbaa4b413b7a3",
+          "revision": "f94aaed28f0a27181bde594b3d7a52f23a00de78",
           "version": null
         }
       },
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/openmobilemaps/maps-core.git",
         "state": {
           "branch": "develop",
-          "revision": "817edd61d9fecda59152d524eed225509b72e805",
+          "revision": "f806a219beac4b237208990a928c8535104b218c",
           "version": null
         }
       }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -143,8 +143,8 @@ dependencies {
 	implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
 	implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2"
 
-	api "io.openmobilemaps:mapscore-dev:1.3.3.109"
-	api "io.openmobilemaps:layer-gps-dev:0.1.2.52"
+	api "io.openmobilemaps:mapscore-dev:1.3.3.110"
+	api "io.openmobilemaps:layer-gps-dev:0.1.2.53"
 
 	testImplementation "junit:junit:4.13.1"
 	androidTestImplementation "androidx.test.ext:junit:1.1.2"

--- a/bridging/android/java/ch/admin/geo/openswissmaps/shared/layers/config/SwisstopoTiledLayerConfigFactory.kt
+++ b/bridging/android/java/ch/admin/geo/openswissmaps/shared/layers/config/SwisstopoTiledLayerConfigFactory.kt
@@ -14,6 +14,11 @@ abstract class SwisstopoTiledLayerConfigFactory {
         }
 
         @JvmStatic
+        fun createRasterTileLayerConfigWithZoomInfo(layerType: SwisstopoLayerType, zoomInfo: io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapZoomInfo?): io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapLayerConfig {
+            return CppProxy.createRasterTileLayerConfigWithZoomInfo(layerType, zoomInfo)
+        }
+
+        @JvmStatic
         fun createRasterTiledLayerConfigFromMetadata(configuration: io.openmobilemaps.mapscore.shared.map.layers.tiled.raster.wmts.WmtsLayerDescription, maxZoom: Int, zoomInfo: io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapZoomInfo): io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapLayerConfig {
             return CppProxy.createRasterTiledLayerConfigFromMetadata(configuration, maxZoom, zoomInfo)
         }
@@ -40,6 +45,9 @@ abstract class SwisstopoTiledLayerConfigFactory {
         companion object {
             @JvmStatic
             external fun createRasterTileLayerConfig(layerType: SwisstopoLayerType): io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapLayerConfig
+
+            @JvmStatic
+            external fun createRasterTileLayerConfigWithZoomInfo(layerType: SwisstopoLayerType, zoomInfo: io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapZoomInfo?): io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapLayerConfig
 
             @JvmStatic
             external fun createRasterTiledLayerConfigFromMetadata(configuration: io.openmobilemaps.mapscore.shared.map.layers.tiled.raster.wmts.WmtsLayerDescription, maxZoom: Int, zoomInfo: io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapZoomInfo): io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapLayerConfig

--- a/bridging/android/jni/layers/config/NativeSwisstopoTiledLayerConfigFactory.cpp
+++ b/bridging/android/jni/layers/config/NativeSwisstopoTiledLayerConfigFactory.cpp
@@ -32,6 +32,16 @@ CJNIEXPORT ::djinni_generated::NativeTiled2dMapLayerConfig::JniType JNICALL Java
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT ::djinni_generated::NativeTiled2dMapLayerConfig::JniType JNICALL Java_ch_admin_geo_openswissmaps_shared_layers_config_SwisstopoTiledLayerConfigFactory_00024CppProxy_createRasterTileLayerConfigWithZoomInfo(JNIEnv* jniEnv, jobject /*this*/, jobject j_layerType, ::djinni_generated::NativeTiled2dMapZoomInfo::Boxed::JniType j_zoomInfo)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE0(jniEnv);
+        auto r = ::SwisstopoTiledLayerConfigFactory::createRasterTileLayerConfigWithZoomInfo(::djinni_generated::NativeSwisstopoLayerType::toCpp(jniEnv, j_layerType),
+                                                                                             ::djinni::Optional<std::optional, ::djinni_generated::NativeTiled2dMapZoomInfo>::toCpp(jniEnv, j_zoomInfo));
+        return ::djinni::release(::djinni_generated::NativeTiled2dMapLayerConfig::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT ::djinni_generated::NativeTiled2dMapLayerConfig::JniType JNICALL Java_ch_admin_geo_openswissmaps_shared_layers_config_SwisstopoTiledLayerConfigFactory_00024CppProxy_createRasterTiledLayerConfigFromMetadata(JNIEnv* jniEnv, jobject /*this*/, ::djinni_generated::NativeWmtsLayerDescription::JniType j_configuration, jint j_maxZoom, ::djinni_generated::NativeTiled2dMapZoomInfo::JniType j_zoomInfo)
 {
     try {

--- a/bridging/ios/STSDKSwisstopoTiledLayerConfigFactory+Private.mm
+++ b/bridging/ios/STSDKSwisstopoTiledLayerConfigFactory+Private.mm
@@ -41,6 +41,15 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
++ (nullable id<MCTiled2dMapLayerConfig>)createRasterTileLayerConfigWithZoomInfo:(STSDKSwisstopoLayerType)layerType
+                                                                       zoomInfo:(nullable MCTiled2dMapZoomInfo *)zoomInfo {
+    try {
+        auto objcpp_result_ = ::SwisstopoTiledLayerConfigFactory::createRasterTileLayerConfigWithZoomInfo(::djinni::Enum<::SwisstopoLayerType, STSDKSwisstopoLayerType>::toCpp(layerType),
+                                                                                                          ::djinni::Optional<std::optional, ::djinni_generated::Tiled2dMapZoomInfo>::toCpp(zoomInfo));
+        return ::djinni_generated::Tiled2dMapLayerConfig::fromCpp(objcpp_result_);
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 + (nullable id<MCTiled2dMapLayerConfig>)createRasterTiledLayerConfigFromMetadata:(nonnull MCWmtsLayerDescription *)configuration
                                                                          maxZoom:(int32_t)maxZoom
                                                                         zoomInfo:(nonnull MCTiled2dMapZoomInfo *)zoomInfo {

--- a/bridging/ios/STSDKSwisstopoTiledLayerConfigFactory.h
+++ b/bridging/ios/STSDKSwisstopoTiledLayerConfigFactory.h
@@ -12,6 +12,9 @@
 
 + (nullable id<MCTiled2dMapLayerConfig>)createRasterTileLayerConfig:(STSDKSwisstopoLayerType)layerType;
 
++ (nullable id<MCTiled2dMapLayerConfig>)createRasterTileLayerConfigWithZoomInfo:(STSDKSwisstopoLayerType)layerType
+                                                                       zoomInfo:(nullable MCTiled2dMapZoomInfo *)zoomInfo;
+
 + (nullable id<MCTiled2dMapLayerConfig>)createRasterTiledLayerConfigFromMetadata:(nonnull MCWmtsLayerDescription *)configuration
                                                                          maxZoom:(int32_t)maxZoom
                                                                         zoomInfo:(nonnull MCTiled2dMapZoomInfo *)zoomInfo;

--- a/djinni/layers/config/layer_configs.djinni
+++ b/djinni/layers/config/layer_configs.djinni
@@ -36,5 +36,7 @@ swisstopo_layer_type = enum
 swisstopo_tiled_layer_config_factory = interface +c {
 	static create_raster_tile_layer_config(layer_type: swisstopo_layer_type) : tiled_2d_map_layer_config;
 
+	static create_raster_tile_layer_config_with_zoom_info(layer_type: swisstopo_layer_type, zoomInfo: optional<tiled_2d_map_zoom_info>) : tiled_2d_map_layer_config;
+
     static create_raster_tiled_layer_config_from_metadata(configuration: wmts_layer_description, maxZoom: i32, zoomInfo: tiled_2d_map_zoom_info) : tiled_2d_map_layer_config;
 }

--- a/shared/public/SwisstopoTiledLayerConfigFactory.h
+++ b/shared/public/SwisstopoTiledLayerConfigFactory.h
@@ -8,6 +8,7 @@
 #include "WmtsLayerDescription.h"
 #include <cstdint>
 #include <memory>
+#include <optional>
 
 enum class SwisstopoLayerType;
 
@@ -16,6 +17,8 @@ public:
     virtual ~SwisstopoTiledLayerConfigFactory() {}
 
     static std::shared_ptr<::Tiled2dMapLayerConfig> createRasterTileLayerConfig(SwisstopoLayerType layerType);
+
+    static std::shared_ptr<::Tiled2dMapLayerConfig> createRasterTileLayerConfigWithZoomInfo(SwisstopoLayerType layerType, const std::optional<::Tiled2dMapZoomInfo> & zoomInfo);
 
     static std::shared_ptr<::Tiled2dMapLayerConfig> createRasterTiledLayerConfigFromMetadata(const ::WmtsLayerDescription & configuration, int32_t maxZoom, const ::Tiled2dMapZoomInfo & zoomInfo);
 };

--- a/shared/src/layers/config/SwisstopoTiledLayerConfigFactory.cpp
+++ b/shared/src/layers/config/SwisstopoTiledLayerConfigFactory.cpp
@@ -16,8 +16,15 @@
 #include "WmtsTiled2dMapLayerConfigFactory.h"
 #include <cmath>
 
+
 std::shared_ptr<::Tiled2dMapLayerConfig>
 SwisstopoTiledLayerConfigFactory::createRasterTileLayerConfig(SwisstopoLayerType layerType) {
+    return createRasterTileLayerConfigWithZoomInfo(layerType, std::nullopt);
+}
+
+std::shared_ptr<::Tiled2dMapLayerConfig>
+SwisstopoTiledLayerConfigFactory::createRasterTileLayerConfigWithZoomInfo(SwisstopoLayerType layerType,
+                                                              const std::optional<Tiled2dMapZoomInfo> &zoomInfo) {
     std::string identifier;
     std::string time = "current";
     std::string extension = "png";
@@ -155,11 +162,9 @@ SwisstopoTiledLayerConfigFactory::createRasterTileLayerConfig(SwisstopoLayerType
     auto configuration = WmtsLayerDescription(identifier, "", "", dimensions, SwisstopoTiledLayerConfigHelper::getBounds(), "2056", "https://wmts.geo.admin.ch/1.0.0/" + identifier +
                                               "/default/{Time}/2056/{TileMatrix}/{TileCol}/{TileRow}." + extension, "image/"+extension);
 
+    auto finalZoomInfo = zoomInfo.has_value() ? *zoomInfo : Tiled2dMapZoomInfo(2.25, numDrawPreviousLayers);
 
-    auto zoomInfo = Tiled2dMapZoomInfo(2.25, numDrawPreviousLayers);
-
-
-    return createRasterTiledLayerConfigFromMetadata(configuration, maxZoom, zoomInfo);
+    return createRasterTiledLayerConfigFromMetadata(configuration, maxZoom, finalZoomInfo);
 }
 
 

--- a/shared/src/layers/config/SwisstopoTiledLayerConfigFactory.cpp
+++ b/shared/src/layers/config/SwisstopoTiledLayerConfigFactory.cpp
@@ -170,8 +170,8 @@ SwisstopoTiledLayerConfigFactory::createRasterTileLayerConfigWithZoomInfo(Swisst
 
 std::shared_ptr<::Tiled2dMapLayerConfig> SwisstopoTiledLayerConfigFactory::createRasterTiledLayerConfigFromMetadata(const ::WmtsLayerDescription & description, int32_t maxZoom, const ::Tiled2dMapZoomInfo & zoomInfo) {
     auto zoomLevels = SwisstopoTiledLayerConfigHelper::getZoomLevelInfos();
-    std::vector<Tiled2dMapZoomLevelInfo> subvector = {zoomLevels.begin(),
-                                                      zoomLevels.begin() + (std::min(zoomLevels.size(), (size_t)maxZoom))};
+    auto itMax = find_if(zoomLevels.begin(), zoomLevels.end(), [&maxZoom] (const Tiled2dMapZoomLevelInfo& s) { return s.zoomLevelIdentifier > maxZoom; } );
+    std::vector<Tiled2dMapZoomLevelInfo> subvector = {zoomLevels.begin(), itMax };
     zoomLevels = subvector;
 
     return WmtsTiled2dMapLayerConfigFactory::create(description, zoomLevels, zoomInfo, SwisstopoTiledLayerConfigHelper::getBounds().topLeft.systemIdentifier, "");


### PR DESCRIPTION
Provide a method for specifying the ZoomConfig when creating one of the default Swisstopo layers. Updated OpenMobileMaps dependencies.