### PR TITLE
Swisstopo Map - ZoomInfo

### DIFF
--- a/android/src/main/java/ch/admin/geo/openswissmaps/util/SwisstopoMapViewInterface.kt
+++ b/android/src/main/java/ch/admin/geo/openswissmaps/util/SwisstopoMapViewInterface.kt
@@ -2,11 +2,14 @@ package ch.admin.geo.openswissmaps.util
 
 import ch.admin.geo.openswissmaps.shared.layers.config.SwisstopoLayerType
 import io.openmobilemaps.mapscore.map.util.MapViewInterface
+import io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapZoomInfo
 import io.openmobilemaps.mapscore.shared.map.layers.tiled.raster.Tiled2dMapRasterLayerInterface
 
 interface SwisstopoMapViewInterface : MapViewInterface {
 	fun setBaseLayerType(layerType: SwisstopoLayerType?)
 	fun setBaseLayerType(identifier: String)
 	fun addSwisstopoLayer(layerType: SwisstopoLayerType): Tiled2dMapRasterLayerInterface
+	fun addSwisstopoLayer(layerType: SwisstopoLayerType, zoomInfo: Tiled2dMapZoomInfo): Tiled2dMapRasterLayerInterface
 	fun addSwisstopoLayer(identifier: String): Tiled2dMapRasterLayerInterface
+	fun addSwisstopoLayer(identifier: String, zoomInfo: Tiled2dMapZoomInfo): Tiled2dMapRasterLayerInterface
 }

--- a/android/src/main/java/ch/admin/geo/openswissmaps/view/SwisstopoMapView.kt
+++ b/android/src/main/java/ch/admin/geo/openswissmaps/view/SwisstopoMapView.kt
@@ -29,6 +29,7 @@ import io.openmobilemaps.mapscore.map.view.MapView
 import io.openmobilemaps.mapscore.shared.map.LayerInterface
 import io.openmobilemaps.mapscore.shared.map.MapConfig
 import io.openmobilemaps.mapscore.shared.map.coordinates.CoordinateSystemFactory
+import io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapZoomInfo
 import io.openmobilemaps.mapscore.shared.map.layers.tiled.raster.Tiled2dMapRasterLayerInterface
 import io.openmobilemaps.mapscore.shared.map.layers.tiled.raster.wmts.WmtsCapabilitiesResource
 import io.openmobilemaps.mapscore.shared.map.loader.LoaderInterface
@@ -129,8 +130,35 @@ class SwisstopoMapView @JvmOverloads constructor(context: Context, attrs: Attrib
         return layer
     }
 
+    override fun addSwisstopoLayer(layerType: SwisstopoLayerType, zoomInfo: Tiled2dMapZoomInfo): Tiled2dMapRasterLayerInterface {
+        val layer = Tiled2dMapRasterLayerInterface.create(
+            SwisstopoTiledLayerConfigFactory.createRasterTileLayerConfigWithZoomInfo(
+                layerType,
+                zoomInfo
+            ), loader
+        )
+        val gpsLayerInterface = gpsLayer?.asLayerInterface()
+        if (gpsLayerInterface != null) {
+            insertLayerBelow(layer.asLayerInterface(), gpsLayerInterface)
+        } else {
+            addLayer(layer.asLayerInterface())
+        }
+        return layer
+    }
+
     override fun addSwisstopoLayer(identifier: String): Tiled2dMapRasterLayerInterface {
         val layer = swisstopoWmtsResource.createLayer(identifier, loader)
+        val gpsLayerInterface = gpsLayer?.asLayerInterface()
+        if (gpsLayerInterface != null) {
+            insertLayerBelow(layer.asLayerInterface(), gpsLayerInterface)
+        } else {
+            addLayer(layer.asLayerInterface())
+        }
+        return layer
+    }
+
+    override fun addSwisstopoLayer(identifier: String, zoomInfo: Tiled2dMapZoomInfo): Tiled2dMapRasterLayerInterface {
+        val layer = swisstopoWmtsResource.createLayerWithZoomInfo(identifier, loader, zoomInfo)
         val gpsLayerInterface = gpsLayer?.asLayerInterface()
         if (gpsLayerInterface != null) {
             insertLayerBelow(layer.asLayerInterface(), gpsLayerInterface)


### PR DESCRIPTION
Allow for ZoomInfo-customization on the SwisstopoMapView and in the SwisstopoOffscreenMapRenderer, don't use adaptScalelToScreen in offscreen rendering by default