### PR TITLE
RasterTile BaseUrl

### DIFF
--- a/bridging/android/java/ch/admin/geo/openswissmaps/shared/layers/config/SwisstopoTiledLayerConfigFactory.kt
+++ b/bridging/android/java/ch/admin/geo/openswissmaps/shared/layers/config/SwisstopoTiledLayerConfigFactory.kt
@@ -19,6 +19,11 @@ abstract class SwisstopoTiledLayerConfigFactory {
         }
 
         @JvmStatic
+        fun createRasterTileLayerConfigWithBaseUrl(layerType: SwisstopoLayerType, zoomInfo: io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapZoomInfo?, baseUrl: String?): io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapLayerConfig {
+            return CppProxy.createRasterTileLayerConfigWithBaseUrl(layerType, zoomInfo, baseUrl)
+        }
+
+        @JvmStatic
         fun createRasterTiledLayerConfigFromMetadata(configuration: io.openmobilemaps.mapscore.shared.map.layers.tiled.raster.wmts.WmtsLayerDescription, maxZoom: Int, zoomInfo: io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapZoomInfo): io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapLayerConfig {
             return CppProxy.createRasterTiledLayerConfigFromMetadata(configuration, maxZoom, zoomInfo)
         }
@@ -48,6 +53,9 @@ abstract class SwisstopoTiledLayerConfigFactory {
 
             @JvmStatic
             external fun createRasterTileLayerConfigWithZoomInfo(layerType: SwisstopoLayerType, zoomInfo: io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapZoomInfo?): io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapLayerConfig
+
+            @JvmStatic
+            external fun createRasterTileLayerConfigWithBaseUrl(layerType: SwisstopoLayerType, zoomInfo: io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapZoomInfo?, baseUrl: String?): io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapLayerConfig
 
             @JvmStatic
             external fun createRasterTiledLayerConfigFromMetadata(configuration: io.openmobilemaps.mapscore.shared.map.layers.tiled.raster.wmts.WmtsLayerDescription, maxZoom: Int, zoomInfo: io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapZoomInfo): io.openmobilemaps.mapscore.shared.map.layers.tiled.Tiled2dMapLayerConfig

--- a/bridging/android/jni/layers/config/NativeSwisstopoTiledLayerConfigFactory.cpp
+++ b/bridging/android/jni/layers/config/NativeSwisstopoTiledLayerConfigFactory.cpp
@@ -42,6 +42,17 @@ CJNIEXPORT ::djinni_generated::NativeTiled2dMapLayerConfig::JniType JNICALL Java
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT ::djinni_generated::NativeTiled2dMapLayerConfig::JniType JNICALL Java_ch_admin_geo_openswissmaps_shared_layers_config_SwisstopoTiledLayerConfigFactory_00024CppProxy_createRasterTileLayerConfigWithBaseUrl(JNIEnv* jniEnv, jobject /*this*/, jobject j_layerType, ::djinni_generated::NativeTiled2dMapZoomInfo::Boxed::JniType j_zoomInfo, jstring j_baseUrl)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE0(jniEnv);
+        auto r = ::SwisstopoTiledLayerConfigFactory::createRasterTileLayerConfigWithBaseUrl(::djinni_generated::NativeSwisstopoLayerType::toCpp(jniEnv, j_layerType),
+                                                                                            ::djinni::Optional<std::optional, ::djinni_generated::NativeTiled2dMapZoomInfo>::toCpp(jniEnv, j_zoomInfo),
+                                                                                            ::djinni::Optional<std::optional, ::djinni::String>::toCpp(jniEnv, j_baseUrl));
+        return ::djinni::release(::djinni_generated::NativeTiled2dMapLayerConfig::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT ::djinni_generated::NativeTiled2dMapLayerConfig::JniType JNICALL Java_ch_admin_geo_openswissmaps_shared_layers_config_SwisstopoTiledLayerConfigFactory_00024CppProxy_createRasterTiledLayerConfigFromMetadata(JNIEnv* jniEnv, jobject /*this*/, ::djinni_generated::NativeWmtsLayerDescription::JniType j_configuration, jint j_maxZoom, ::djinni_generated::NativeTiled2dMapZoomInfo::JniType j_zoomInfo)
 {
     try {

--- a/bridging/ios/STSDKSwisstopoTiledLayerConfigFactory+Private.mm
+++ b/bridging/ios/STSDKSwisstopoTiledLayerConfigFactory+Private.mm
@@ -50,6 +50,17 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
++ (nullable id<MCTiled2dMapLayerConfig>)createRasterTileLayerConfigWithBaseUrl:(STSDKSwisstopoLayerType)layerType
+                                                                      zoomInfo:(nullable MCTiled2dMapZoomInfo *)zoomInfo
+                                                                       baseUrl:(nullable NSString *)baseUrl {
+    try {
+        auto objcpp_result_ = ::SwisstopoTiledLayerConfigFactory::createRasterTileLayerConfigWithBaseUrl(::djinni::Enum<::SwisstopoLayerType, STSDKSwisstopoLayerType>::toCpp(layerType),
+                                                                                                         ::djinni::Optional<std::optional, ::djinni_generated::Tiled2dMapZoomInfo>::toCpp(zoomInfo),
+                                                                                                         ::djinni::Optional<std::optional, ::djinni::String>::toCpp(baseUrl));
+        return ::djinni_generated::Tiled2dMapLayerConfig::fromCpp(objcpp_result_);
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 + (nullable id<MCTiled2dMapLayerConfig>)createRasterTiledLayerConfigFromMetadata:(nonnull MCWmtsLayerDescription *)configuration
                                                                          maxZoom:(int32_t)maxZoom
                                                                         zoomInfo:(nonnull MCTiled2dMapZoomInfo *)zoomInfo {

--- a/bridging/ios/STSDKSwisstopoTiledLayerConfigFactory.h
+++ b/bridging/ios/STSDKSwisstopoTiledLayerConfigFactory.h
@@ -15,6 +15,10 @@
 + (nullable id<MCTiled2dMapLayerConfig>)createRasterTileLayerConfigWithZoomInfo:(STSDKSwisstopoLayerType)layerType
                                                                        zoomInfo:(nullable MCTiled2dMapZoomInfo *)zoomInfo;
 
++ (nullable id<MCTiled2dMapLayerConfig>)createRasterTileLayerConfigWithBaseUrl:(STSDKSwisstopoLayerType)layerType
+                                                                      zoomInfo:(nullable MCTiled2dMapZoomInfo *)zoomInfo
+                                                                       baseUrl:(nullable NSString *)baseUrl;
+
 + (nullable id<MCTiled2dMapLayerConfig>)createRasterTiledLayerConfigFromMetadata:(nonnull MCWmtsLayerDescription *)configuration
                                                                          maxZoom:(int32_t)maxZoom
                                                                         zoomInfo:(nonnull MCTiled2dMapZoomInfo *)zoomInfo;

--- a/djinni/layers/config/layer_configs.djinni
+++ b/djinni/layers/config/layer_configs.djinni
@@ -39,5 +39,7 @@ swisstopo_tiled_layer_config_factory = interface +c {
 
 	static create_raster_tile_layer_config_with_zoom_info(layer_type: swisstopo_layer_type, zoomInfo: optional<tiled_2d_map_zoom_info>) : tiled_2d_map_layer_config;
 
+	static create_raster_tile_layer_config_with_base_url(layer_type: swisstopo_layer_type, zoomInfo: optional<tiled_2d_map_zoom_info>, base_url: optional<string>) : tiled_2d_map_layer_config;
+
     static create_raster_tiled_layer_config_from_metadata(configuration: wmts_layer_description, maxZoom: i32, zoomInfo: tiled_2d_map_zoom_info) : tiled_2d_map_layer_config;
 }

--- a/shared/public/SwisstopoTiledLayerConfigFactory.h
+++ b/shared/public/SwisstopoTiledLayerConfigFactory.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 
 enum class SwisstopoLayerType;
 
@@ -19,6 +20,8 @@ public:
     static std::shared_ptr<::Tiled2dMapLayerConfig> createRasterTileLayerConfig(SwisstopoLayerType layerType);
 
     static std::shared_ptr<::Tiled2dMapLayerConfig> createRasterTileLayerConfigWithZoomInfo(SwisstopoLayerType layerType, const std::optional<::Tiled2dMapZoomInfo> & zoomInfo);
+
+    static std::shared_ptr<::Tiled2dMapLayerConfig> createRasterTileLayerConfigWithBaseUrl(SwisstopoLayerType layerType, const std::optional<::Tiled2dMapZoomInfo> & zoomInfo, const std::optional<std::string> & baseUrl);
 
     static std::shared_ptr<::Tiled2dMapLayerConfig> createRasterTiledLayerConfigFromMetadata(const ::WmtsLayerDescription & configuration, int32_t maxZoom, const ::Tiled2dMapZoomInfo & zoomInfo);
 };

--- a/shared/src/layers/config/SwisstopoTiledLayerConfigFactory.cpp
+++ b/shared/src/layers/config/SwisstopoTiledLayerConfigFactory.cpp
@@ -19,12 +19,20 @@
 
 std::shared_ptr<::Tiled2dMapLayerConfig>
 SwisstopoTiledLayerConfigFactory::createRasterTileLayerConfig(SwisstopoLayerType layerType) {
-    return createRasterTileLayerConfigWithZoomInfo(layerType, std::nullopt);
+    return createRasterTileLayerConfigWithBaseUrl(layerType, std::nullopt, std::nullopt);
 }
 
 std::shared_ptr<::Tiled2dMapLayerConfig>
 SwisstopoTiledLayerConfigFactory::createRasterTileLayerConfigWithZoomInfo(SwisstopoLayerType layerType,
-                                                              const std::optional<Tiled2dMapZoomInfo> &zoomInfo) {
+                                                                          const std::optional<Tiled2dMapZoomInfo> &zoomInfo) {
+    return createRasterTileLayerConfigWithBaseUrl(layerType, zoomInfo, std::nullopt);
+}
+
+
+std::shared_ptr<::Tiled2dMapLayerConfig>
+SwisstopoTiledLayerConfigFactory::createRasterTileLayerConfigWithBaseUrl(SwisstopoLayerType layerType,
+                                                                         const std::optional<::Tiled2dMapZoomInfo> &zoomInfo,
+                                                                         const std::optional<std::string> &baseUrl) {
     std::string identifier;
     std::string time = "current";
     std::string extension = "png";
@@ -160,8 +168,9 @@ SwisstopoTiledLayerConfigFactory::createRasterTileLayerConfigWithZoomInfo(Swisst
     }
 
 
+    std::string url = baseUrl.has_value() ? *baseUrl : "https://wmts.geo.admin.ch/1.0.0/";
     auto dimensions = { WmtsLayerDimension("Time", time, {}) };
-    auto configuration = WmtsLayerDescription(identifier, "", "", dimensions, SwisstopoTiledLayerConfigHelper::getBounds(), "2056", "https://wmts.geo.admin.ch/1.0.0/" + identifier +
+    auto configuration = WmtsLayerDescription(identifier, "", "", dimensions, SwisstopoTiledLayerConfigHelper::getBounds(), "2056", url + identifier +
                                               "/default/{Time}/2056/{TileMatrix}/{TileCol}/{TileRow}." + extension, "image/"+extension);
 
     auto finalZoomInfo = zoomInfo.has_value() ? *zoomInfo : Tiled2dMapZoomInfo(0.65, numDrawPreviousLayers, true);


### PR DESCRIPTION
Provide an option to create a Swisstopo raster layer config with a custom base url.