### PR TITLE
Fixes iOS resources

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
             path: "ios",
             exclude: ["README.md", "docs/install_readme.md"],
             resources: [
+                .process("resources/wmts/WMTSCapabilities_2056.xml")
             ]
         ),
         .target(

--- a/ios/SwisstopoCapabilitiesResource.swift
+++ b/ios/SwisstopoCapabilitiesResource.swift
@@ -17,7 +17,7 @@ public class SwisstopoCapabilitiesResource {
     private init() {}
 
     public static let capabilitiesResource: MCWmtsCapabilitiesResource = {
-        let url = Bundle(for: SwisstopoCapabilitiesResource.self).url(forResource: "WMTSCapabilities_2056", withExtension: "xml")
+        let url = Bundle.module.url(forResource: "WMTSCapabilities_2056", withExtension: "xml")
         let xml = try! String(contentsOf: url!)
         let resource = MCWmtsCapabilitiesResource.create(xml)!
         return resource


### PR DESCRIPTION
- Ich glaube SwisstopoCapabilitiesResource wird statisch gelinked, weshalb Bundle(for: SwisstopoCapabilitiesResource.self) trotzdem den Path zum MainApp-Bundle zurück gibt (e.g. /SAC-CAS.app). Bundle.module zeigt aber immer auf das Bundle des SPM-Package (e.g. /SAC-CAS.app/SwisstopoMapSDK_SwisstopoMapSDK.bundle), weshalb ich zu dem zurück wechseln würde

- Damit Bundle.module funktioniert, muss mindestens ein .resource referenziert sein, damit SPM das resource_bundle_accessor file generiert, mit welchem man Bundle.module accessen kann.